### PR TITLE
Update CMakeLists.txt to allow FetchContent to work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_library(mygal INTERFACE)
 target_include_directories(mygal INTERFACE 
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>  
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>  
     $<INSTALL_INTERFACE:include>)
 
 # Code coverage
@@ -60,5 +60,5 @@ install(FILES
     ${CMAKE_BINARY_DIR}/MyGALConfigVersion.cmake
     ${CMAKE_BINARY_DIR}/MyGALConfig.cmake
     DESTINATION lib/cmake/MyGAL)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/ DESTINATION include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ write_basic_package_version_file(
     VERSION 
     COMPATIBILITY AnyNewerVersion)
 configure_package_config_file(
-    ${CMAKE_SOURCE_DIR}/cmake/MyGALConfig.cmake.in
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/MyGALConfig.cmake.in
     ${CMAKE_BINARY_DIR}/MyGALConfig.cmake
     INSTALL_DESTINATION lib/cmake/MyGAL)
 


### PR DESCRIPTION
When trying to use this library with CMake's FetchContent command like so:

```
set(BUILD_EXAMPLES OFF)
set(BUILD_TESTING OFF)
FetchContent_Declare(
        MyGAL
        GIT_REPOSITORY https://github.com/pvigier/MyGAL
        GIT_SHALLOW TRUE
)
FetchContent_MakeAvailable(MyGAL)
```

I ran into a build issue where the configure_package_config_file was looking for  MyGALConfig.cmake.in inside my project instead of the _deps/mygal-src folder that the FetchContent command downloads everything into. Swapping from CMAKE_SOURCE_DIR which is the the top level source directory to CMAKE_CURRENT_LIST_DIR which is the directory of the currently parsed CMakeLists.txt file should resolve it for standard builds and FetchContent builds.

Also let me know if there is an issue with this PR as I've not used GitHub's pull request system enough to be confident I have it correct.