### PR TITLE
Remove warning about class and struct mismatch

### DIFF
--- a/include/MyGAL/Event.h
+++ b/include/MyGAL/Event.h
@@ -28,7 +28,7 @@ namespace mygal
 {
 
 template<typename T>
-class Arc;
+struct Arc;
 
 template<typename T>
 class Event


### PR DESCRIPTION
A fix for this warning:

```
warning: class template 'Arc' was previously declared as a struct template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
class Arc;
```